### PR TITLE
Use port 8080 instead of 80

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,4 +12,4 @@ RUN poetry install --no-root --only main
 
 COPY ../ ./
 
-CMD ["fastapi", "run", "main.py", "--port", "80", "--proxy-headers"]
+CMD ["fastapi", "run", "main.py", "--port", "8080", "--proxy-headers"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       ARIES_VCR_URL: ${ARIES_VCR_URL:-http://vcr-api:8080}
     ports:
-      - "3333:80"
+      - "3333:8080"
     networks:
       - orgbook
 


### PR DESCRIPTION
Port 80 is privileged in many systems, including OCP. Use port 8080 as an unprivileged alternative.

I thought about using parameters it, but it seems overkill for what is needed.