### PR TITLE
chore: temporary issuer registry in configuration file

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,5 +4,16 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     aries_vcr_url: str = "http://host.docker.internal:8080"
 
+    ISSUERS: list = [
+        {
+            "id": "did:web:test.digitaltrust.traceability.site:petroleum-and-natural-gas-act:director-of-petroleum-lands",
+            "name": "Director of Petroleum Lands",
+        },
+        {
+            "id": "did:web:test.digitaltrust.traceability.site:mines-act:chief-permitting-officer",
+            "name": "Chief Permitting Officer",
+        },
+    ]
+
 
 settings = Settings()


### PR DESCRIPTION
Needs to be leveraged to validate incoming credential-types and credentials, as well as to provision issuers in orgbook.